### PR TITLE
Turn shutit_main entirely into functions

### DIFF
--- a/shutit_main.py
+++ b/shutit_main.py
@@ -267,7 +267,7 @@ def check_ready(config_dict, shutit_map, shutit_id_list):
 
 def do_remove(config_dict, shutit_map, shutit_id_list):
 	# Now get the run_order keys in order and go.
-	shutit_id_list = run_order_modules(config_dict, shutit_id_list)
+	shutit_id_list = run_order_modules(shutit_map, shutit_id_list)
 	util.log(util.red('PHASE: remove'))
 	if config_dict['build']['tutorial']:
 		util.pause_point(util.get_pexpect_child('container_child'),'\nNow removing any modules that need removing',print_input=False)


### PR DESCRIPTION
Moves everything that was previously running in the global scope to function scopes.
This makes it much easier to reason about what variables are being modified where, and therefore makes it easier to make small, self contained changes.

Additionally, it is now possible to import shutit without it trying to run as a script.
This is a prerequisite to using shutit as a backend for anything.
