### PR TITLE
Remove cidfile creation, sanity checks on docker, reduce cmd delay

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,10 +179,13 @@ class conn_docker(ShutItModule):
 		# Some pexpect settings
 		shutit.pexpect_children['host_child'] = host_child
 		shutit.pexpect_children['container_child'] = container_child
-		shutit.set_default_expect(cfg['expect_prompts']['base_prompt'])
+		shutit.set_default_expect(base_prompt)
 		host_child.logfile = container_child.logfile = sys.stdout
 		host_child.maxread = container_child.maxread = 2000
 		host_child.searchwindowsize = container_child.searchwindowsize = 1024
+		# Race conditions have been seen - might want to remove this
+		delay = cfg['build']['command_pause']
+		host_child.delaybeforesend = container_child.delaybeforesend = delay
 		# Set up prompts and let the user do things before the build
 		# host child
 		shutit.set_default_child(host_child)

--- a/shutit_global.py
+++ b/shutit_global.py
@@ -148,8 +148,6 @@ class ShutIt(object):
 			self.log('================================================================================')
 			self.log('Sending>>>' + send + '<<<')
 			self.log('Expecting>>>' + str(expect) + '<<<')
-		# Race conditions have been seen - might want to remove this
-		time.sleep(cfg['build']['command_pause'])
 		child.sendline(send)
 		expect_res = child.expect(expect,timeout)
 		if cfg['build']['debug']:

--- a/util.py
+++ b/util.py
@@ -261,7 +261,7 @@ def parse_args(cfg):
 		sub_parsers[action].add_argument('-s', '--set', help='Override a config item, e.g. "-s container rm no". Can be specified multiple times.', default=[], action='append', nargs=3, metavar=('SEC','KEY','VAL'))
 		sub_parsers[action].add_argument('--image_tag', help='Build container using specified image - if there is a symbolic reference, please use that, eg localhost.localdomain:5000/myref',default=cfg['container']['docker_image_default'])
 		sub_parsers[action].add_argument('--shutit_module_path', default='.',help='List of shutit module paths, separated by colons. ShutIt registers modules by running all .py files in these directories.')
-		sub_parsers[action].add_argument('--pause',help='Pause between commands to avoid race conditions.',default='0.5')
+		sub_parsers[action].add_argument('--pause',help='Pause between commands to avoid race conditions.',default='0.2')
 		sub_parsers[action].add_argument('--debug',help='Show debug. Implies [build]/interactive config settings set, even if set to "no".',default=False,const=True,action='store_const')
 		sub_parsers[action].add_argument('--tutorial',help='Show tutorial info. Implies [build]/interactive config setting set, even if set to "no".',default=False,const=True,action='store_const')
 


### PR DESCRIPTION
- No more cidfiles littering /tmp
- We've had people confused by why the command was hanging when actually the password hadn't been set in the config. To aid in this is a) tries --version b) tries info. If one of these don't work we report a helpful error message, if they do we know we have connection to a docker daemon.
- Pexpect has a built-in delaybeforesend option. Use this so the delays apply to every command (including checks like files existing etc). I also reduced the delay a little (now that the delay applies to every command) to stop builds grinding to an unbearable slowdown - I figure shutit seems to be stable enough at the moment to take the risk. As a result, builds appear to be faster.
