### PR TITLE
Fix very long build reports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,16 +218,7 @@ class conn_docker(ShutItModule):
 		# Put build info into the container
 		shutit.send_and_expect('mkdir -p /root/shutit_build')
 		logfile = cfg['build']['container_build_log']
-		shutit.send_and_expect('touch ' + logfile)
-		print_conf = 'cat > ' + logfile + """ << LOGFILEEND
-""" + util.print_config(cfg) + """
-LOGFILEEND"""
-		shutit.send_and_expect(print_conf,record_command=False)
-		build_rep = """cat > """ + logfile + """ << BUILDREPEND
-""" + util.build_report('') + """
-BUILDREPEND"""
-		# Do we need this check_exit=False?
-		shutit.send_and_expect(build_rep,record_command=False,check_exit=False)
+		shutit.send_file(logfile, util.build_report(''))
 		# Finish with the container
 		shutit.pexpect_children['container_child'].sendline('exit') # Exit container
 


### PR DESCRIPTION
Note that I've removed the printing of config to the build log...because it wasn't making it in there anyway - the second cat overwrote rather than appended.

If you want to add the config as well, might be worth double checking there's no sensitive information in any existing modules that might get printed.
