### PR TITLE
Correctly set up the root environment in docker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ class conn_docker(ShutItModule):
 				'-t',
 				'-i',
 				cfg['container']['docker_image'],
-				'/bin/bash'
+				'su', '-s', '/bin/bash', 'root'
 			] if arg != ''
 		]
 		if cfg['build']['interactive'] >= 3:


### PR DESCRIPTION
Currently $HOME is set to '/'. This is not the home environment directory for root - running '/bin/bash' doesn't set it up right for whatever reason.
