### PR TITLE
Config booleans overwritten with strings

### DIFF
--- a/shutit_global.py
+++ b/shutit_global.py
@@ -1791,6 +1791,7 @@ class ShutIt(object):
 				self.fail('Config item: ' + option + ':\nin module:\n[' + module_id + ']\nmust be set!\n\nOften this is a deliberate requirement to place in your ~/.shutit/config file.', throw_exception=False)
 			self.cfg[module_id][option] = default
 
+
 	def record_config(self):
 		""" Put the config in a file in the target.
 		"""


### PR DESCRIPTION
Bit of a confusing one to explain, as discussed last night with @ianmiell. There are a few commits on my fork, I realised I could make the fix simpler when I tried to explain it.

This situation comes about when I have some config (in build.cnf for my module) that I expect to be boolean.

Both the following would blow in this example (as False is still grabbed as a string from configparser):

my_config:no
my_config:False

See my (SH:) comments in the following:

``` python
def config_collection_for_built(shutit):
    """Collect configuration for modules that are being built.
    When this is called we should know what's being built (ie after
    dependency resolution).
    """
    for module_id in module_ids(shutit):
        # Get the config even if installed or building (may be needed in other
        # hooks, eg test).
        if (is_built(shutit, shutit.shutit_map[module_id]) and
            not shutit.shutit_map[module_id].get_config(shutit)):
                shutit.fail(module_id + ' failed on get_config')

        # SH: my config is loaded here fine type(bool)

        # Collect the build.cfg if we are building here.
        # If this file exists, process it.
        # We could just read in the file and process only those 
        # that relate to the module_id.
        if shutit.cfg[module_id]['shutit.core.module.build']:
            module = shutit.shutit_map[module_id]
            cfg_file = os.path.dirname(module.__module_file) + '/configs/build.cnf'
            if os.path.isfile(cfg_file):

                # SH: we end up in here as we're building the module
                # and have a config file

                # use shutit.get_config, forcing the passed-in default
                import ConfigParser
                config_parser = ConfigParser.ConfigParser()
                config_parser.read(cfg_file)
                for section in config_parser.sections():
                    if section == module_id:
                        for option in config_parser.options(section):

                            # SH: problem is here, we load the config from file as a string
                            # and pass it through with forcedefault, so it ends up as 
                            # a string in the config array as opposed to a bool
                            value = config_parser.get(section,option)
                            if option == 'shutit.core.module.allowed_images':
                                value = json.loads(value)
                            shutit.get_config(module_id, option,
                                              value, forcedefault=True)
```

My proposed fix is to check whether the existing value we've got (from the first block above) is boolean, and if so use getboolean.
