### PR TITLE
send_file, basename spaces and path expansion

### DIFF
--- a/shutit_global.py
+++ b/shutit_global.py
@@ -474,7 +474,7 @@ class ShutIt(object):
 		contents64 = base64.standard_b64encode(contents)
 		# if replace funny chars
 		path = path.replace(' ', '\ ')
-		child.sendline("base64 --decode > '" + path + "'")
+		child.sendline("base64 --decode > " + path)
 		child.expect('\r\n')
 		# We have to batch the file up to avoid hitting pipe buffer limit. This
 		# is 4k on modern machines (it seems), but we choose 4000b for safety


### PR DESCRIPTION
I've just done this to start the discussion. I've tested and I'm not sure why we need the quotes. The escaping you've put in works fine for me.

``` python
shutit.send_file('~/this file contains spaces home dir','SHUTIT_FILE_SPACES_TEST_BLAH_BLAH_BLAH')
```

produced this for me:

SHUTIT_shutit.tk.composer.composer#W6zrg099>ls -ltr
total 24
-rwxr-xr-x 1 root root   49 Nov 25 19:12 stop_informix.sh
-rwxr-xr-x 1 root root  362 Nov 25 19:12 start_informix.sh
-rw-r--r-- 1 root root   38 Nov 26 19:47 this file contains spaces home dir
drwxr-xr-x 6 root root 4096 Nov 26 19:48 shutit_build
-rwxr-xr-x 1 root root  140 Nov 26 19:48 start_ssh_server.sh
-rwxr-xr-x 1 root root   70 Nov 26 19:48 stop_ssh_server.sh
SHUTIT_shutit.tk.composer.composer#W6zrg099>cat this\ file\ contains\ spaces\ home\ dir 
SHUTIT_FILE_SPACES_TEST_BLAH_BLAH_BLAHSHUTIT_shutit.tk.composer.composer#W6zrg099>

Which seems to have worked OK?

Do you have a usecase which is failing that I can look into? If not merge!
