### PR TITLE
build.conf override overrides

### DIFF
--- a/shutit_main.py
+++ b/shutit_main.py
@@ -228,6 +228,13 @@ def config_collection_for_built(shutit):
 				for section in config_parser.sections():
 					if section == module_id:
 						for option in config_parser.options(section):
+							override = False
+							for mod, opt, val in shutit.cfg['build']['config_overrides']:
+								# skip overrides
+								if mod == module_id and opt == option:
+									override = True
+							if override:
+								continue
 							is_bool = (type(shutit.cfg[module_id][option]) == bool)
 							if is_bool:
 								value = config_parser.getboolean(section,option)


### PR DESCRIPTION
I'm finding that a config defined in my build.conf is overriding an argument passed in on the command line (but only when I'm explicitly building the given module, I think).

I don't fully follow what config_collection_for_built is doing, so I might be missing the point here?

Also I'm sure there's a much more pythonic way of doing this but google didn't help me.
