### PR TITLE
get_file not working for concurrent builds / multiple users on one host

### DIFF
--- a/alerting/emailer.py
+++ b/alerting/emailer.py
@@ -174,8 +174,7 @@ class Emailer():
 		"""
 		shutit = self.shutit
 		host_path = '/tmp'
-		host_fn = os.path.join(host_path, os.path.basename(filename))
-		shutit.get_file(filename, host_path)
+		host_fn = shutit.get_file(filename, host_path)
 		if self.config['shutit.core.alerting.emailer.compress']:
 			filetype = 'x-gzip-compressed'
 			filename = self.__gzip(host_fn)

--- a/shutit_global.py
+++ b/shutit_global.py
@@ -990,8 +990,9 @@ class ShutIt(object):
 			if user != 'root':
 				shutit.login(user)
 		shutit.send('cp ' + target_path + ' /artifacts')
-		shutil.copyfile(os.path.join(artifacts_dir,filename),os.path.join(host_path,filename))
+		shutil.copyfile(os.path.join(artifacts_dir,filename),os.path.join(host_path,'{0}_'.format(shutit.cfg['build']['build_id']) + filename))
 		shutit.send('rm -f /artifacts/' + filename)
+		return os.path.join(host_path,'{0}_'.format(shutit.cfg['build']['build_id']) + filename)
 
 
 	def prompt_cfg(self, msg, sec, name, ispass=False):


### PR DESCRIPTION
We found a problem with get_file whereby one user is able to overwrite another user's files (or not able to write at all depending on the umask).

We've added build_id to the file path to make sure they will always be unique and returned the path as part of the call (so you don't have to work it out for yourself in the calling code).

This will affect users of get_file (as they will now need to use the path returned). There are no instances in the shutit core library.

Note this change was written by @tpdlocke.