### PR TITLE
Set default locale in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -542,6 +542,7 @@ class setup(ShutItModule):
 		shutit.add_to_bashrc('export HISTSIZE=99999999')
 		# Ignore leading-space commands in the history.
 		shutit.add_to_bashrc('export HISTCONTROL=ignorespace:cmdhist')
+		shutit.add_to_bashrc('export LANG=' + shutit.cfg['target']['locale'])
 		if shutit.cfg['target']['install_type'] == 'apt':
 			shutit.add_to_bashrc('export DEBIAN_FRONTEND=noninteractive')
 			if do_update:


### PR DESCRIPTION
Seems reasonably sane, given the config isn't used anywhere else...