### PR TITLE
Moved from using sys.version_info.major and minor to use [0] and [1]

### DIFF
--- a/shutit.py
+++ b/shutit.py
@@ -63,8 +63,8 @@ def main():
 	"""
 	# Create base shutit object.
 	shutit = shutit_global.shutit_global_object.shutit_objects[0]
-	if sys.version_info.major == 2:
-		if sys.version_info.minor < 7:
+	if sys.version_info[0] == 2:
+		if sys.version_info[1] < 7:
 			shutit.fail('Python version must be 2.7+') # pragma: no cover
 	shutit.setup_shutit_obj()
 


### PR DESCRIPTION
When trying to run shutit from a box running python 2.6.6 the version check fails as sys.version_info.major doesn't exist. Moved to a more general format which allows it to fail nicely

Error:

lib/python2.6/site-packages/shutit_pexpect.py:47: DeprecationWarning: the md5 module is deprecated; use hashlib instead
  from md5 import md5
Traceback (most recent call last):
  File "/home/whiterob/.local/bin/shutit", line 11, in <module>
    sys.exit(main())
  File "/home/whiterob/.local/lib/python2.6/site-packages/shutit.py", line 66, in main
    if sys.version_info.major == 2:
AttributeError: 'tuple' object has no attribute 'major'